### PR TITLE
Use lint:fix command instead lint

### DIFF
--- a/.github/workflows/nodejs-lint.yml
+++ b/.github/workflows/nodejs-lint.yml
@@ -13,4 +13,4 @@ jobs:
           node-version: 14.x
       - run: |
           yarn
-          yarn lint
+          yarn lint:fix


### PR DESCRIPTION
Ao invés de rodarmos o lint para encontrar problemas no código poderíamos tentar sempre dar um fix antes de alertar. Caso o fix não funcione ele vai apontar falha da mesma forma.