### PR TITLE
fix: gh_token not required

### DIFF
--- a/.github/workflows/nodejs-build-to-ecr.yml
+++ b/.github/workflows/nodejs-build-to-ecr.yml
@@ -17,7 +17,7 @@ on:
         required: true
       
       gh_token:
-        required: true
+        required: false
 
     inputs:
       ecr_repository:

--- a/.github/workflows/nodejs-lint.yml
+++ b/.github/workflows/nodejs-lint.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     secrets:
       gh_token:
-        required: true
+        required: false
 
 jobs:
   lint:

--- a/.github/workflows/nodejs-tests.yml
+++ b/.github/workflows/nodejs-tests.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     secrets:
       gh_token:
-        required: true
+        required: false
 
 jobs:
   tests:


### PR DESCRIPTION
removendo a obrigação do gh_token nos flows para evitar quebrar os builds